### PR TITLE
Use standard library mock when available

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,10 @@ setup(
     # $ pip install -e .[dev,test]
     extras_require={
         'dev': ['check-manifest'],
-        'test': ['coverage'],
+        'test': [
+            'pytest',
+            'mock; python_version<"3.3"'
+        ],
     },
 
     # If there are data files included in your packages that need to be

--- a/test/test_parsers.py
+++ b/test/test_parsers.py
@@ -1,7 +1,12 @@
 from __future__ import print_function
 
 import unittest
-import mock
+
+try:
+    import unittest.mock as mock
+except ImportError:
+    import mock
+
 import six
 
 import easyargs

--- a/tox.ini
+++ b/tox.ini
@@ -12,4 +12,4 @@ commands =
     py.test
 deps =
     pytest
-    mock
+    mock; python_version<"3.3"


### PR DESCRIPTION
Mock has been available in the standard library since Python 3.3.  There is no need to install the pypi package on modern Pythons.