### PR TITLE
Add support for Python 3.6 through 3.11

### DIFF
--- a/easyargs/main.py
+++ b/easyargs/main.py
@@ -36,7 +36,10 @@ def create_sub_parser(parser, method_info):
 
     # Get the arguments for the method
     # TODO: do something sensible with args and varargs
-    args, _, _, defaults = inspect.getargspec(method)
+    try:
+        args, _, _, defaults, _, _, _ = inspect.getfullargspec(method)
+    except AttributeError:
+        args, _, _, defaults = inspect.getargspec(method)
 
     num_positional = len(args)
     if defaults is not None:

--- a/easyargs/parsers.py
+++ b/easyargs/parsers.py
@@ -106,7 +106,11 @@ def function_parser(function, parser):
     main_text, params_help = parser_help_text(help_text)
 
     # Get the function information
-    args, varargs, keywords, defaults = inspect.getargspec(function)
+    try:
+        args, varargs, keywords, defaults, _, _, _ = inspect.getfullargspec(function)
+    except AttributeError:
+        args, varargs, keywords, defaults = inspect.getargspec(function)
+
     if args is None:
         args = []
 

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,12 @@ setup(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
     ],
 
     # What does your project relate to?

--- a/tox.ini
+++ b/tox.ini
@@ -4,12 +4,11 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, py33, py34, py35
+envlist = py26, py27, py33, py34, py35, py36, py37, py38, py39, py310, py311
 
 [testenv]
 commands =
-    {envpython} setup.py test
-    py.test
+    pytest
 deps =
     pytest
     mock


### PR DESCRIPTION
I noticed this package in Fedora was failing to rebuild with Python 3.11.  `inspect.getargspec` has been removed.  `inspect.getfullargspec` is the updated API, but returns a tuple with more properties.  With that handled in a try/except block, the tests pass on 3.6.15, 3.7.13, 3.8.13, 3.9.12, 3.10.4, and 3.11.0a7.